### PR TITLE
Update guess_string_to_dict() to cloudnetpy target classification description

### DIFF
--- a/pyLARDA/helpers.py
+++ b/pyLARDA/helpers.py
@@ -233,8 +233,15 @@ def guess_str_to_dict(string):
         #probalby already the stringified python format
         return ast.literal_eval(string)
 
+    elif "\nValue" in string:
+        # the cloudnetpy format \nValue 0: desc\n ....
+        d = {}
+        for e in string.split('\nValue '):
+            k, v = e.split(':')
+            d[int(k)] = v.strip()
+        return d
     elif "\n" in string:
-        #the cloudnet format 0: desc\n ....
+        # the cloudnet format 0: desc\n ....
         d = {}
         for e in string.split('\n'):
             k, v = e.split(':')

--- a/pyLARDA/helpers.py
+++ b/pyLARDA/helpers.py
@@ -237,8 +237,9 @@ def guess_str_to_dict(string):
         # the cloudnetpy format \nValue 0: desc\n ....
         d = {}
         for e in string.split('\nValue '):
-            k, v = e.split(':')
-            d[int(k)] = v.strip()
+            if len(e) > 0:
+                k, v = e.split(':')
+                d[int(k)] = v.strip()
         return d
     elif "\n" in string:
         # the cloudnet format 0: desc\n ....


### PR DESCRIPTION
The cloudnetpy target classification has a different [definition attribute](https://github.com/actris-cloudnet/cloudnetpy/blob/a89e23a2c2d1f51d3b6d62ee327132ef123343bd/cloudnetpy/products/classification.py#L89) than the matlab version. This includes this new format in the helper function.